### PR TITLE
Add decorator support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-	"presets": ["es2015", "react", "stage-0"]
+	"presets": ["es2015", "react", "stage-0"],
+	"plugins": ["transform-decorators-legacy"]
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-env": "^1.6.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",


### PR DESCRIPTION
@hamzaerbay 
btw, the way I got this working was first to try to use a decorator. This resulting in this message being printed to the JS console:

```
Module build failed: SyntaxError: Decorators are not officially supported yet in 6.x pending a proposal update.
However, if you need to use them you can install the legacy decorators transform with:
npm install babel-plugin-transform-decorators-legacy --save-dev
and add the following line to your .babelrc file:
{
  "plugins": ["transform-decorators-legacy"]
}
The repo url is: https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy.
```

I followed the directions and now decorators work!